### PR TITLE
Disabled GitHub Token requirement

### DIFF
--- a/.github/actions/local-action/action.yml
+++ b/.github/actions/local-action/action.yml
@@ -4,7 +4,7 @@ author: githubtraining
 inputs:
   exercise-token:
     description: GITHUB_TOKEN used to access the API
-    required: true
+    required: false
 
 runs:
   using: node12


### PR DESCRIPTION
- Unable to proceed with exercise due to workflow not having repository write permission in GitHub Token.

- Unable to enable write permission in repository setting.